### PR TITLE
Support for TextBlock API format changed from KakaoWork 1.7 or higher

### DIFF
--- a/news/131.enhancement
+++ b/news/131.enhancement
@@ -1,0 +1,1 @@
+Support for TextBlock API format changed from KakaoWork 1.7 or higher


### PR DESCRIPTION
Thanks for contributing to kakaowork-py

### Description

<!-- Describe the goal of this PR. Mention any related Issue numbers. -->
Support for TextBlock API format changed from KakaoWork 1.7 or higher. Resolves #131 

### Checklist

- [x] Added **a news fragment** in the `news` directory to describe this fix with the issue or pr number and the extension such as `.breaking`, `.feature`, `.enhancement`, `.bugfix`, `.deprecation`, `.removal`, `.doc` or `.misc`.
- [x] Added **any related issues**
- [x] Added **tests** for changed code.
