### PR TITLE
Changed to specifications for blockkit properties

### DIFF
--- a/kakaowork/blockkit.py
+++ b/kakaowork/blockkit.py
@@ -83,7 +83,7 @@ class TextInline(BaseModel):
     bold: Optional[bool] = None
     italic: Optional[bool] = None
     strike: Optional[bool] = None
-    color: Optional[Union[TextInlineColor, str]] = None
+    color: Optional[TextInlineColor] = None
     url: Optional[str] = None
 
     class Config:
@@ -230,7 +230,7 @@ class ButtonBlock(Block):
     _max_len_text: ClassVar[int] = 20
 
     text: str
-    style: ButtonStyle
+    style: ButtonStyle = ButtonStyle.DEFAULT
     action_type: Optional[ButtonActionType] = None
     action_name: Optional[str] = None
     value: Optional[str] = None
@@ -260,7 +260,7 @@ class HeaderBlock(Block):
     _max_len_text: ClassVar[int] = 20
 
     text: str
-    style: HeaderStyle
+    style: HeaderStyle = HeaderStyle.BLUE
 
     def __init__(self, **data):
         if 'type' not in data:
@@ -279,7 +279,7 @@ class HeaderBlock(Block):
 class ActionBlock(Block):
     _max_len_elements: ClassVar[int] = 3
 
-    elements: List[ButtonBlock] = []
+    elements: List[ButtonBlock]
 
     def __init__(self, **data) -> None:
         if 'type' not in data:

--- a/news/157.breaking
+++ b/news/157.breaking
@@ -1,0 +1,1 @@
+Changed to specifications for blockkit properties

--- a/tests/blockkit_test.py
+++ b/tests/blockkit_test.py
@@ -402,9 +402,14 @@ class TestActionBlock:
 
     def test_from_dict(self):
         with pytest.raises(ValidationError):
+            ActionBlock(**{})
+
+        with pytest.raises(ValidationError):
             ActionBlock(**{"type": "####", "elements": [{"type": "button", "text": "hello", "style": "default"}]})
 
-        assert ActionBlock(**{}) == ActionBlock()
+        with pytest.raises(ValidationError):
+            ActionBlock(**{'elements': []})
+
         assert ActionBlock(**{
             "elements": [{
                 "type": "button",


### PR DESCRIPTION
Thanks for contributing to kakaowork-py

### Description

<!-- Describe the goal of this PR. Mention any related Issue numbers. -->
Changed to specifications for blockkit properties.

- The TextInline color property can only be a TextInlineColor type variable.
- The ButtonBlock style property default value is ButtonStyle.DEFAULT.
- The HeaderBlock style property default value is HeaderStyle.BLUE.
- The ActionBlock elements property is now required.

### Checklist

- [x] Added **a news fragment** in the `news` directory to describe this fix with the issue or pr number and the extension such as `.breaking`, `.feature`, `.enhancement`, `.bugfix`, `.deprecation`, `.removal`, `.doc` or `.misc`.
- [ ] Added **any related issues**
- [x] Added **tests** for changed code.
